### PR TITLE
Fix for 4.6 - can't enable/disable permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ nz.co.fuzion.relatedpermissions
 ===============================
 
 Empowers inherited permissions throughout Civi. Note that the latest version allows you to specify that certain relationships
-should alsways be permissioned BUT it is dependent on  https://github.com/eileenmcnaughton/nz.co.fuzion.entitysetting
+should always be permissioned BUT it is dependent on  https://github.com/eileenmcnaughton/nz.co.fuzion.entitysetting
 
 Because of the dependency the later version is not available for automated download
 You also need this commit (in 4.4.6)

--- a/info.xml
+++ b/info.xml
@@ -14,8 +14,8 @@
     <author>Eileen McNaughton</author>
     <email>eileen@fuzion.co.nz</email>
   </maintainer>
-  <releaseDate>2013-10-29</releaseDate>
-  <version>1.1</version>
+  <releaseDate>2014-09-23</releaseDate>
+  <version>1.2</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>4.2</ver>

--- a/info.xml
+++ b/info.xml
@@ -14,16 +14,17 @@
     <author>Eileen McNaughton</author>
     <email>eileen@fuzion.co.nz</email>
   </maintainer>
-  <releaseDate>2014-09-23</releaseDate>
-  <version>1.2</version>
+  <releaseDate>2013-10-29</releaseDate>
+  <version>1.1</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>4.2</ver>
     <ver>4.3</ver>
     <ver>4.4</ver>
+    <ver>4.5</ver>
+    <ver>4.6</ver>
   </compatibility>
-  <comments>This extension makes the permission flag on a relationship work as a true ACL. In core CiviCRM that flag only allows the user to see the contact dashboard. However, in many cases it is a useful mechanism to give people permission to view contact records and search for contacts.
-  This version requires civicrm_entity extension and should not be used on a 4.4 version less than 4.4.6. This version also allows relationship types to be forced to being permissioned (via the relationship config screen) </comments>
+  <comments>This extension makes the permission flag on a relationship work as a true ACL. In core CiviCRM that flag only allows the user to see the contact dashboard. However, in many cases it is a useful mechanism to give people permission to view contact records and search for contacts.</comments>
   <civix>
     <namespace>CRM/Relatedpermissions</namespace>
   </civix>

--- a/relatedpermissions.php
+++ b/relatedpermissions.php
@@ -232,25 +232,35 @@ function calculateInheritedPermissions($tmpTableSecondaryContacts, $tmpTableName
 
 /**
  * Set permissions if required
- * @param unknown $a
- * @param unknown $b
+ *
+ * @param string operation
+ * @param object entity
+ * @param int entity ID
+ * @param array entity
  */
 function relatedpermissions_civicrm_pre($op, $entity, $objectID, &$entityArray) {
   if($entity != 'Relationship' || $op == 'delete') {
     return;
   }
-  $relationshipType = explode('_', $entityArray['relationship_type_id']);
 
-  if(_relatedpermissions_is_permission($relationshipType[0], 'a_b')) {
-    $entityArray['is_permission_a_b'] = TRUE;
-  }
-  if(_relatedpermissions_is_permission($relationshipType[0], 'b_a')) {
-    $entityArray['is_permission_b_a'] = TRUE;
+  if (isset($entityArray['relationship_type_id'])) {
+    $relationshipType = explode('_', $entityArray['relationship_type_id']);
+    $entity_id = $relationshipType[0];
+
+    if (is_numeric($entity_id)) {
+      if(_relatedpermissions_is_permission($entity_id, 'a_b')) {
+        $entityArray['is_permission_a_b'] = TRUE;
+      }
+      if(_relatedpermissions_is_permission($entity_id, 'b_a')) {
+        $entityArray['is_permission_b_a'] = TRUE;
+      }
+    }
   }
 }
 
 /**
- * Get permission for a given entity id in a given direction
+ * Get permission for a given entity id in a given direction.
+ *
  * @param integer $entity_id
  * @param string $direction
  * @return Ambigous <null, array>


### PR DESCRIPTION
There are a couple of other trivia changes in this PR, but the interesting part is just the additional checking which needs to be done in `relatedpermissions_civicrm_pre()`, to ensure that you have the required entity ID before making the API call.
