### PR TITLE
Specify 5.5 as minimum Civi version

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -18,7 +18,7 @@
   <version>1.4</version>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>5.3</ver>
+    <ver>5.5</ver>
   </compatibility>
   <comments>This extension makes the permission flag on a relationship work as a true ACL. In core CiviCRM that flag only allows the user to see the contact dashboard. However, in many cases it is a useful mechanism to give people permission to view contact records and search for contacts.
  This version also allows relationship types to be forced to being permissioned (via the relationship config screen) </comments>


### PR DESCRIPTION
I installed this on a test site, but it fails on upgrade.  From CLI I can see the error:
```
  [Symfony\Component\Debug\Exception\FatalThrowableError]                               
  Call to undefined method CRM_Core_SelectValues::getPermissionedRelationshipOptions()
```
That function is in the 5.5 and master branches, but nothing lower.  This should prevent the extension coming up as upgradeable on lower versions of CiviCRM.