### PR TITLE
Support overriding is_permission_a_b/b_a on Relationship.Get API

### DIFF
--- a/CRM/Relatedpermissions/APIWrapper.php
+++ b/CRM/Relatedpermissions/APIWrapper.php
@@ -1,0 +1,25 @@
+<?php
+
+class CRM_Relatedpermissions_APIWrapper implements API_Wrapper {
+  /**
+   * the wrapper contains a method that allows you to alter the parameters of the api request (including the action and the entity)
+   */
+  public function fromApiInput($apiRequest) {
+    if ('Invalid' == CRM_Utils_Array::value('contact_type', $apiRequest['params'])) {
+      $apiRequest['params']['contact_type'] = 'Individual';
+    }
+    return $apiRequest;
+  }
+
+  /**
+   * alter the result before returning it to the caller.
+   */
+  public function toApiOutput($apiRequest, $result) {
+    if (($apiRequest['entity'] === 'Relationship') && ($apiRequest['action'] === 'get')) {
+      foreach ($result['values'] as $index => &$relationship) {
+        $relationship = CRM_Relatedpermissions_Utils_Relatedpermissions::enforcePermissions($relationship);
+      }
+      return $result;
+    }
+  }
+}

--- a/CRM/Relatedpermissions/Upgrader.php
+++ b/CRM/Relatedpermissions/Upgrader.php
@@ -35,7 +35,7 @@ class CRM_Relatedpermissions_Upgrader extends CRM_Relatedpermissions_Upgrader_Ba
       $customGroups = civicrm_api3('CustomGroup', 'create', [
         'extends' => 'RelationshipType',
         'name' => E::SHORT_NAME,
-        'title' => E::ts('Related Permssions Settings'),
+        'title' => E::ts('Related Permissions Settings'),
       ]);
     }
     $customFields = civicrm_api3('CustomField', 'get', [
@@ -55,6 +55,7 @@ class CRM_Relatedpermissions_Upgrader extends CRM_Relatedpermissions_Upgrader_Ba
         'custom_group_id' => $customGroups['id'],
         'name' => 'permission_a_b_mode',
         'label' => E::ts('Permission A over B mode'),
+        'help_post' => E::ts("If set to 'Override' this permission will be enforced and cannot be changed for individual relationships."),
         'weight' => 2,
         'data_type' => 'Integer',
         'html_type' => 'Radio',
@@ -75,6 +76,7 @@ class CRM_Relatedpermissions_Upgrader extends CRM_Relatedpermissions_Upgrader_Ba
         'custom_group_id' => $customGroups['id'],
         'name' => 'permission_b_a_mode',
         'label' => E::ts('Permission B over A mode'),
+        'help_post' => E::ts("If set to 'Override' this permission will be enforced and cannot be changed for individual relationships."),
         'weight' => 4,
         'data_type' => 'Integer',
         'html_type' => 'Radio',

--- a/CRM/Relatedpermissions/Utils/Relatedpermissions.php
+++ b/CRM/Relatedpermissions/Utils/Relatedpermissions.php
@@ -41,4 +41,23 @@ class CRM_Relatedpermissions_Utils_Relatedpermissions {
     return \Civi::$statics[__CLASS__]['custom_fields'];
   }
 
+  /**
+   * Given a relationship array, enforce the permissions and return the array with the updated permissions
+   *
+   * @param array $relationship
+   */
+  public static function enforcePermissions($relationship) {
+    $permissionSettings = CRM_Relatedpermissions_Utils_Relatedpermissions::getSettings($relationship['relationship_type_id']);
+    foreach (['a_b', 'b_a'] as $direction) {
+      // check mode & value....
+      if ($permissionSettings['permission_' . $direction . '_mode']) {
+        if ($permissionSettings['permission_' . $direction] != '') {
+          // enforce
+          $relationship['is_permission_' . $direction] = $permissionSettings['permission_' . $direction];
+        }
+      }
+    }
+    return $relationship;
+  }
+
 }

--- a/README.md
+++ b/README.md
@@ -2,8 +2,4 @@ nz.co.fuzion.relatedpermissions
 ===============================
 
 Empowers inherited permissions throughout Civi. Note that the latest version allows you to specify that certain relationships
-should alsways be permissioned BUT it is dependent on  https://github.com/eileenmcnaughton/nz.co.fuzion.entitysetting
-
-Because of the dependency the later version is not available for automated download
-You also need this commit (in 4.4.6)
-https://github.com/civicrm/civicrm-core/commit/9deb4ed30cd8127c8e187016b6e2d6bc3b03bcbc
+should always be permissioned.

--- a/TODO.md
+++ b/TODO.md
@@ -1,21 +1,23 @@
 # ToDo list for RelatedPermssions extension
 
 ## Sort out default values
-
  - idea is that admin can set mode to 'enforce' or 'default'
- - in 'enforce' mode, the admin-set perm overrides anything else: in GUI, in Rel Add/Edit the other options are disabled. In API it should override
- - in 'default' mode, the admin-set perm is selected by default in Rel Add/Edit.  In API, it is used if permission_a_b is not specificed
+ 
+### Enforce Mode
+The admin-set perm overrides anything else.
+ - In GUI, in Rel Add/Edit the other options are disabled. - *Working but get browser message "[object] Object" when loading*
+ - In API it overrides the returned values for is_permission_a_b/b_a - **Working.**
+ 
+#### Default Mode
+ - In API, it is used if permission_a_b is not specified. - *TODO, API values currently not touched in default mode*
+ - The admin-set perm is selected by default in Rel Add/Edit. - *TODO: Not working -see below:*
 
-But:
- in Add/Edit, the form default value is 0 not '', despite setDefaults setting it to '' so not able to distinguish between unset and 0 (None)
-
+But: in Add/Edit, the form default value is 0 not '', despite setDefaults setting it to '' so not able to distinguish between unset and 0 (None)
 
 ## Improve creation of custom values:
 
- - on Admin > Customize > Relationship Types > Edit, the custom values are editable - make them reserved ?
+ - on Admin > Customize > Relationship Types > Edit, the custom values are editable - make them reserved?
  - on Admin > Settings > Option Groups there are two groups each for Permission & Permission mode - could just be one of each
 
-## There is no upgrade path from entitysettings 
-
+## There is no upgrade path from entitysettings
   - could do this in the Upgrader but is it worth the effort?
- 

--- a/relatedpermissions.php
+++ b/relatedpermissions.php
@@ -340,30 +340,13 @@ function relatedpermissions_civicrm_pre($op, $entity, $objectID, &$entityArray) 
   }
 }
 
-// --- Functions below this ship commented out. Uncomment as required. ---
-
 /**
- * Implements hook_civicrm_preProcess().
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_preProcess
- *
-function relatedpermissions_civicrm_preProcess($formName, &$form) {
-
-} // */
-
-/**
- * Implements hook_civicrm_navigationMenu().
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_navigationMenu
- *
-function relatedpermissions_civicrm_navigationMenu(&$menu) {
-  _relatedpermissions_civix_insert_navigation_menu($menu, 'Mailings', array(
-    'label' => E::ts('New subliminal message'),
-    'name' => 'mailing_subliminal_message',
-    'url' => 'civicrm/mailing/subliminal',
-    'permission' => 'access CiviMail',
-    'operator' => 'OR',
-    'separator' => 0,
-  ));
-  _relatedpermissions_civix_navigationMenu($menu);
-} // */
+ * Implements hook_civicrm_apiWrappers
+ */
+function relatedpermissions_civicrm_apiWrappers(&$wrappers, $apiRequest) {
+  //&apiWrappers is an array of wrappers, you can add your(s) with the hook.
+  // You can use the apiRequest to decide if you want to add the wrapper (eg. only wrap api.Contact.create)
+  if ($apiRequest['entity'] == 'Relationship' && $apiRequest['action'] == 'get') {
+    $wrappers[] = new CRM_Relatedpermissions_APIWrapper();
+  }
+}

--- a/relatedpermissions.php
+++ b/relatedpermissions.php
@@ -332,7 +332,7 @@ function relatedpermissions_civicrm_pre($op, $entity, $objectID, &$entityArray) 
       }
     }
     else {
-      if ($permissionSettings['permission_' . $direction] != '' && $entityArray['is_permission_' . $direction] == '') {
+      if (isset($permissionSettings['permission_' . $direction]) && $entityArray['is_permission_' . $direction] == '') {
         // default
         $entityArray['is_permission_' . $direction] = $permissionSettings['permission_' . $direction];
       }


### PR DESCRIPTION
This adds support for overriding Relationship permissions via the API.

I've also updated the TODO/README, please check if the changes are correct?