### PR TITLE
Fix setting of permission defaults for b_a relationships

### DIFF
--- a/js/set_permissions.js
+++ b/js/set_permissions.js
@@ -10,18 +10,27 @@ CRM.$(function($) {
     $('input[type="radio"][name="is_permission_b_a"][value="' + origBA + '"]').prop('checked', true);
     // on Add Relationship screen, relationship type is not set
     // on Edit Relationship screen, relationship type is current type
-    var relType = $(this).val();
-    if (!relType) {
+    var relTypeId = $(this).val();
+    if (!relTypeId) {
       return;
     }
+    var relType = relTypeId.substr(relTypeId.length - 3);
 
-    CRM.api3('Relationship', 'getsettings', { relationship_type_id: relType })
+    CRM.api3('Relationship', 'getsettings', { relationship_type_id: relTypeId })
       .done(function (data) {
         if (data.values) {
           var ABmode = data.values.permission_a_b_mode;
           var BAmode = data.values.permission_b_a_mode;
-          var ABperm = data.values.permission_a_b;
-          var BAperm = data.values.permission_b_a;
+          var ABperm;
+          var BAperm;
+          if (relType == 'a_b') {
+            ABperm = data.values.permission_a_b;
+            BAperm = data.values.permission_b_a;
+          }
+          else {
+            ABperm = data.values.permission_b_a;
+            BAperm = data.values.permission_a_b;
+          }
           var alert = 0;
           if (ABmode == 1) {
             // Enforce mode


### PR DESCRIPTION
To replicate -

- Allow Parent to have permission to the child contact by selecting "View And Update"  for `Permission that B has over A` field on Child-Parent relationship type.

![image](https://user-images.githubusercontent.com/5929648/64686121-c5848700-d4a5-11e9-8a17-dafa62c64eef.png)

- Go to any individual contact and open "Add relationship" form.

- Select Parent Of in the type.

- Notice that the default permission is incorrectly set to 

![image](https://user-images.githubusercontent.com/5929648/64686196-e4831900-d4a5-11e9-97bd-0d8f7b89cc24.png)
