### PR TITLE
Fix setting default of some relationship types

### DIFF
--- a/CRM/Relatedpermissions/Utils/Relatedpermissions.php
+++ b/CRM/Relatedpermissions/Utils/Relatedpermissions.php
@@ -8,6 +8,7 @@ class CRM_Relatedpermissions_Utils_Relatedpermissions {
       $fields = CRM_Relatedpermissions_Utils_Relatedpermissions::getPermissionFields();
       $res = civicrm_api3('RelationshipType', 'get', [
         'return' => array_keys($fields),
+        'options' => ['limit' => 0],
       ]);
       $permissionSettings = [];
       foreach ($res['values'] as $relType) {


### PR DESCRIPTION
If relationship types are more than 25, the extension does not select default permission for some of them if selected on the relationship form.

Extending the API to return all relationship types.