### PR TITLE
Remove calls to deprecated CRM_Utils_Array::value

### DIFF
--- a/CRM/Relatedpermissions/Utils/Relatedpermissions.php
+++ b/CRM/Relatedpermissions/Utils/Relatedpermissions.php
@@ -21,7 +21,7 @@ class CRM_Relatedpermissions_Utils_Relatedpermissions {
       \Civi::$statics[__CLASS__]['permission_settings'] = $permissionSettings;
     }
     if ($relationshipType) {
-      return CRM_Utils_Array::value($relationshipType, \Civi::$statics[__CLASS__]['permission_settings']);
+      return \Civi::$statics[__CLASS__]['permission_settings'][$relationshipType] ?? NULL;
     }
     else {
       return \Civi::$statics[__CLASS__]['permission_settings'];

--- a/api/v3/Relationship/Getsettings.php
+++ b/api/v3/Relationship/Getsettings.php
@@ -23,7 +23,7 @@ function _civicrm_api3_relationship_getsettings_spec(&$spec) {
  * @throws API_Exception
  */
 function civicrm_api3_relationship_getsettings($params) {
-  $type = CRM_Utils_Array::value('relationship_type_id', $params);
+  $type = $params['relationship_type_id'] ?? NULL;
   if ($type) {
     // Allow rel to have a_b part
     $bits = explode("_", $type);


### PR DESCRIPTION
Replaces deprecated function with equivalent null-coalescing operator. Behavior should be the same before/after.