### PR TITLE
Replace reference to deprecated exception class

### DIFF
--- a/api/v3/Relationship/Getsettings.php
+++ b/api/v3/Relationship/Getsettings.php
@@ -20,7 +20,7 @@ function _civicrm_api3_relationship_getsettings_spec(&$spec) {
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_relationship_getsettings($params) {
   $type = CRM_Utils_Array::value('relationship_type_id', $params);

--- a/api/v3/Relationship/PruneTempTables.php
+++ b/api/v3/Relationship/PruneTempTables.php
@@ -19,7 +19,7 @@ function _civicrm_api3_relationship_prune_temp_tables_spec(&$spec) {
  * @return array API result descriptor
  * @see civicrm_api3_create_success()
  * @see civicrm_api3_create_error()
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_relationship_prune_temp_tables($params) {
   try {
@@ -44,6 +44,6 @@ function civicrm_api3_relationship_prune_temp_tables($params) {
     return civicrm_api3_create_success($return_values, $params, 'Relationship', 'rp_prune_temp_tables');
   }
   catch (Exception $e) {
-    throw new API_Exception('Error clearing temp tables.');
+    throw new CRM_Core_Exception('Error clearing temp tables.');
   }
 }


### PR DESCRIPTION
The api-specific exception classes have been deprecated and will soon be removed from core.
They are identical to CRM_Core_Exception.