### PR TITLE
#52 Fixes issue related to aclWhere, granting relationship modification, and Searchkit save,edit action permissions

### DIFF
--- a/Civi/Relatedpermissions/Check.php
+++ b/Civi/Relatedpermissions/Check.php
@@ -11,7 +11,7 @@ class Check extends AutoSubscriber {
 
   public static function getSubscribedEvents() {
     return [
-      '&hook_civicrm_aclWhereClause' => ['hook_civicrm_aclWhereClause'],
+      '&hook_civicrm_aclWhereClause' => ['aclWhereClause'],
       'civi.api4.authorizeRecord' => ['onApiAuthorizeRecord'],
       'civi.api.authorize' => ['onApiAuthorize'],
     ];
@@ -174,7 +174,7 @@ class Check extends AutoSubscriber {
    * Implement WHERE Clause - we find the contacts for whom this contact has permission and
    * specifically give permission to them
    */
-  function hook_civicrm_aclWhereClause($type, &$tables, &$whereTables, &$contactID, &$where) {
+  function aclWhereClause($type, &$tables, &$whereTables, &$contactID, &$where) {
     if (!$contactID) {
       return;
     }
@@ -212,7 +212,8 @@ class Check extends AutoSubscriber {
       return;
     }
 
-    if ($apiRequest->getEntityName() !== 'Contact') {
+    // We probably want to make this a setting at some point since custom subtypes aren't included
+    if (!in_array($apiRequest->getEntityName(), ['Contact', 'Individual', 'Household', 'Organization'])) {
       return;
     }
 
@@ -251,7 +252,7 @@ class Check extends AutoSubscriber {
     }
 
     // Contact.getFields/getActions should be allowed if contact can see/edit one or more contacts
-    if (in_array($apiRequest->getEntityName(), ['Contact', 'Email'])
+    if (in_array($apiRequest->getEntityName(), ['Contact', 'Individual', 'Organization', 'Email', 'Relationship'])
       && in_array($apiRequest->getActionName(), ['getFields', 'getActions'])) {
 
       $loggedInContactID = \CRM_Core_Session::getLoggedInContactID();
@@ -282,12 +283,7 @@ class Check extends AutoSubscriber {
         $permissionType = \CRM_Core_Permission::VIEW;
     }
 
-    $contact = Contact::get(FALSE)
-      ->addSelect('id', 'contact_type')
-      ->addWhere('id', '=', $loggedInContactID)
-      ->execute()
-      ->first();
-    $this->buildPermissionsTable($contact['id'], $permissionType);
+    $this->buildPermissionsTable($loggedInContactID, $permissionType);
   }
 
 }

--- a/Civi/Relatedpermissions/Check.php
+++ b/Civi/Relatedpermissions/Check.php
@@ -2,7 +2,6 @@
 namespace Civi\Relatedpermissions;
 
 use Civi\API\Events;
-use Civi\Api4\Contact;
 use Civi\Api4\Event\AuthorizeRecordEvent;
 use Civi\Core\Service\AutoSubscriber;
 use CRM_Relatedpermissions_ExtensionUtil as E;
@@ -77,24 +76,24 @@ class Check extends AutoSubscriber {
     }
 
     $sql = "INSERT INTO $this->tmpTableName
-    SELECT DISTINCT contact_id_a FROM civicrm_relationship
-    WHERE contact_id_b = $contactID
-    AND is_active = 1
-    AND (start_date IS NULL OR start_date <= '{$now}' )
-    AND (end_date IS NULL OR end_date >= '{$now}')
-    AND is_permission_b_a $permissionClause
-  ";
+      SELECT DISTINCT contact_id_a FROM civicrm_relationship
+      WHERE contact_id_b = $contactID
+      AND is_active = 1
+      AND (start_date IS NULL OR start_date <= '{$now}' )
+      AND (end_date IS NULL OR end_date >= '{$now}')
+      AND is_permission_b_a $permissionClause
+    ";
 
     \CRM_Core_DAO::executeQuery($sql);
 
     $sql = "REPLACE INTO $this->tmpTableName
-    SELECT contact_id_b FROM civicrm_relationship
-    WHERE contact_id_a = $contactID
-    AND is_active = 1
-    AND (start_date IS NULL OR start_date <= '{$now}' )
-    AND (end_date IS NULL OR end_date >= '{$now}')
-    AND is_permission_a_b $permissionClause
-  ";
+      SELECT contact_id_b FROM civicrm_relationship
+      WHERE contact_id_a = $contactID
+      AND is_active = 1
+      AND (start_date IS NULL OR start_date <= '{$now}' )
+      AND (end_date IS NULL OR end_date >= '{$now}')
+      AND is_permission_a_b $permissionClause
+    ";
 
     \CRM_Core_DAO::executeQuery($sql);
 
@@ -111,12 +110,14 @@ class Check extends AutoSubscriber {
       while ($continue > 0) {
         $this->calculateInheritedPermissions($tmpTableSecondaryContacts, $now, $permissionClause);
         $newPotentialPermissionInheritingContacts = \CRM_Core_DAO::singleValueQuery("
-     SELECT count(*) FROM $tmpTableSecondaryContacts s
-     LEFT JOIN $this->tmpTableName m ON s.contact_id = m.contact_id
-     WHERE m.contact_id IS NULL AND s.contact_type IN ('Organization', 'Household')");
+          SELECT count(*) FROM $tmpTableSecondaryContacts s
+          LEFT JOIN $this->tmpTableName m ON s.contact_id = m.contact_id
+          WHERE m.contact_id IS NULL AND s.contact_type IN ('Organization', 'Household')
+         ");
+
         $sql = "REPLACE INTO $this->tmpTableName
-      SELECT contact_id FROM $tmpTableSecondaryContacts
-    ";
+          SELECT contact_id FROM $tmpTableSecondaryContacts
+        ";
 
         \CRM_Core_DAO::executeQuery($sql);
         //keep going as long as we are adding
@@ -212,8 +213,8 @@ class Check extends AutoSubscriber {
       return;
     }
 
-    // We probably want to make this a setting at some point since custom subtypes aren't included
-    if (!in_array($apiRequest->getEntityName(), ['Contact', 'Individual', 'Household', 'Organization'])) {
+    $contactTypes = $this->getContactTypes();
+    if (!in_array($apiRequest->getEntityName(), $contactTypes)) {
       return;
     }
 
@@ -252,7 +253,9 @@ class Check extends AutoSubscriber {
     }
 
     // Contact.getFields/getActions should be allowed if contact can see/edit one or more contacts
-    if (in_array($apiRequest->getEntityName(), ['Contact', 'Individual', 'Organization', 'Email', 'Relationship'])
+    $entityTypes = $this->getContactTypes();
+    $entityTypes = array_merge($entityTypes, ['Email', 'Relationship']);
+    if (in_array($apiRequest->getEntityName(), $entityTypes)
       && in_array($apiRequest->getActionName(), ['getFields', 'getActions'])) {
 
       $loggedInContactID = \CRM_Core_Session::getLoggedInContactID();
@@ -286,4 +289,14 @@ class Check extends AutoSubscriber {
     $this->buildPermissionsTable($loggedInContactID, $permissionType);
   }
 
+  /**
+   * Get Basic Contact Types
+   * 
+   * @return array
+   */
+  private function getContactTypes() : array {
+    $contactTypes = \CRM_Contact_BAO_ContactType::basicTypes();
+    $contactTypes[] = 'Contact';
+    return $contactTypes;
+  }
 }


### PR DESCRIPTION
# Description

Dealing with #52 and #51 I fixed a few things that should handle Searchkit being able to run properly. There were some minor changes

+ Fixed the `hook_civicrm` function name since this was never called (I think b/c it is called Hook but who knows
+ Added more Contact types (see below) to process actions
+ Added the ability to change Relationships
+ Removed Contact lookup since we have the ID already

# Notes

I think it would be better to actually retrieve all the Entities that are of ContactType instead of hardcoding

cc @mattwire 