### PR TITLE
Allow all contact types in A-B-C permission chaining

### DIFF
--- a/Civi/Relatedpermissions/Check.php
+++ b/Civi/Relatedpermissions/Check.php
@@ -139,7 +139,7 @@ class Check extends AutoSubscriber {
     SELECT DISTINCT contact_id_b, contact_b.contact_type
     FROM $this->tmpTableName tmp
     LEFT JOIN civicrm_relationship r  ON tmp.contact_id = r.contact_id_a
-    INNER JOIN civicrm_contact c ON c.id = r.contact_id_a AND c.contact_type IN ('Household', 'Organization')
+    INNER JOIN civicrm_contact c ON c.id = r.contact_id_a
     INNER JOIN civicrm_contact contact_b ON contact_b.id = r.contact_id_b
     WHERE
     r.is_active = 1
@@ -155,7 +155,7 @@ class Check extends AutoSubscriber {
     SELECT contact_id_a, contact_b.contact_type
     FROM $this->tmpTableName tmp
     LEFT JOIN civicrm_relationship r ON tmp.contact_id = r.contact_id_b
-    INNER JOIN civicrm_contact c ON c.id = r.contact_id_b AND c.contact_type IN ('Household', 'Organization')
+    INNER JOIN civicrm_contact c ON c.id = r.contact_id_b
     INNER JOIN civicrm_contact contact_b ON contact_b.id = r.contact_id_b
     WHERE
     r.is_active = 1


### PR DESCRIPTION
Currently `calculateInheritedPermissions()` restricts the middle contact (B in an A→B→C chain) to only Organisation and Household types. This means sites where all contacts are Individual cannot use chained permissions at all.

This removes the contact_type filter from both SQL queries, allowing Individual contacts to also act as the middle contact in a permission chain.